### PR TITLE
Call python when invoking deciles-charts

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,1 +1,1 @@
-run: python:latest analysis/deciles_charts.py
+run: python:latest python analysis/deciles_charts.py


### PR DESCRIPTION
This is necessary for running deciles-charts on Windows backends.