### PR TITLE
Specify an input glob pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Remember to replace `[version]` with [a deciles-charts version][4]:
 generate_deciles_charts:
   run: >
     deciles-charts:[version]
-      --input_dir output
+      --input-files output/measure_*.csv
       --output_dir output
   needs: [generate_measures]
   outputs:

--- a/analysis/deciles_charts.py
+++ b/analysis/deciles_charts.py
@@ -1,4 +1,5 @@
 import argparse
+import glob
 import pathlib
 import re
 
@@ -17,18 +18,12 @@ def _get_group_by(measure_table):
     return list(measure_table.columns[:-4])
 
 
-def get_measure_tables(path):
-    if not path.is_dir():
-        raise AttributeError()
-
-    for sub_path in path.iterdir():
-        if not sub_path.is_file():
-            continue
-
-        measure_fname_match = re.match(MEASURE_FNAME_REGEX, sub_path.name)
+def get_measure_tables(input_files):
+    for input_file in input_files:
+        measure_fname_match = re.match(MEASURE_FNAME_REGEX, input_file.name)
         if measure_fname_match is not None:
             # The `date` column is assigned by the measures framework.
-            measure_table = pandas.read_csv(sub_path, parse_dates=["date"])
+            measure_table = pandas.read_csv(input_file, parse_dates=["date"])
 
             # We can reconstruct the parameters passed to `Measure` without
             # the study definition.
@@ -52,13 +47,21 @@ def write_deciles_chart(deciles_chart, path):
     deciles_chart.savefig(path)
 
 
+def get_path(*args):
+    return pathlib.Path(*args).resolve()
+
+
+def match_paths(pattern):
+    return [get_path(x) for x in glob.glob(pattern)]
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--input-dir",
+        "--input-files",
         required=True,
-        type=pathlib.Path,
-        help="Path to the input directory",
+        type=match_paths,
+        help="Glob pattern for matching one or more input files",
     )
     parser.add_argument(
         "--output-dir",
@@ -71,10 +74,10 @@ def parse_args():
 
 def main():
     args = parse_args()
-    input_dir = args.input_dir
+    input_files = args.input_files
     output_dir = args.output_dir
 
-    for measure_table in get_measure_tables(input_dir):
+    for measure_table in get_measure_tables(input_files):
         measure_table = drop_zero_denominator_rows(measure_table)
         chart = get_deciles_chart(measure_table)
         id_ = measure_table.attrs["id"]

--- a/analysis/deciles_charts.py
+++ b/analysis/deciles_charts.py
@@ -66,7 +66,7 @@ def parse_args():
     parser.add_argument(
         "--output-dir",
         required=True,
-        type=pathlib.Path,
+        type=get_path,
         help="Path to the output directory",
     )
     return parser.parse_args()

--- a/project.yaml
+++ b/project.yaml
@@ -27,7 +27,7 @@ actions:
   generate_deciles_charts:
     run: >
       python:latest analysis/deciles_charts.py
-        --input-dir output
+        --input-files output/measure_*.csv
         --output-dir output
     needs: [generate_measures]
     outputs:

--- a/tests/test_deciles_charts.py
+++ b/tests/test_deciles_charts.py
@@ -4,43 +4,43 @@ from pandas import testing
 from analysis import deciles_charts
 
 
-class TestGetMeasureTables:
+def test_get_measure_tables(tmp_path):
     # For each measure, the measures framework writes a csv for each week/month, adding
     # the date as a suffix to the file name; and a csv for all weeks/months, adding the
     # date to a column in the file. We define a "measure table" as the latter, because
     # it's easier to work with one file, than with many files/file names. However, it's
     # hard to write a glob pattern that matches the latter but not the former, so
     # `get_measure_tables` filters `input_files`.
-    def test_measure_table(self, tmp_path):
-        # arrange
-        # this is a csv for a week/month
-        input_file_1 = tmp_path / "measure_sbp_by_practice_2021-01-01.csv"
-        input_file_1.touch()
 
-        # this is a csv for all weeks/months
-        measure_table_in = pandas.DataFrame(
-            {
-                "practice": [1],  # group_by
-                "has_sbp_event": [1],  # numerator
-                "population": [1],  # denominator
-                "value": [1],  # assigned by the measures framework
-                "date": ["2021-01-01"],  # assigned by the measures framework
-            }
-        )
-        measure_table_in["date"] = pandas.to_datetime(measure_table_in["date"])
-        input_file_2 = tmp_path / "measure_sbp_by_practice.csv"
-        measure_table_in.to_csv(input_file_2, index=False)
+    # arrange
+    # this is a csv for a week/month
+    input_file_1 = tmp_path / "measure_sbp_by_practice_2021-01-01.csv"
+    input_file_1.touch()
 
-        # act
-        measure_table_out = next(
-            deciles_charts.get_measure_tables([input_file_1, input_file_2])
-        )
+    # this is a csv for all weeks/months
+    measure_table_in = pandas.DataFrame(
+        {
+            "practice": [1],  # group_by
+            "has_sbp_event": [1],  # numerator
+            "population": [1],  # denominator
+            "value": [1],  # assigned by the measures framework
+            "date": ["2021-01-01"],  # assigned by the measures framework
+        }
+    )
+    measure_table_in["date"] = pandas.to_datetime(measure_table_in["date"])
+    input_file_2 = tmp_path / "measure_sbp_by_practice.csv"
+    measure_table_in.to_csv(input_file_2, index=False)
 
-        # assert
-        testing.assert_frame_equal(measure_table_out, measure_table_in)
-        assert measure_table_out.attrs["id"] == "sbp_by_practice"
-        assert measure_table_out.attrs["denominator"] == "population"
-        assert measure_table_out.attrs["group_by"] == ["practice"]
+    # act
+    measure_table_out = next(
+        deciles_charts.get_measure_tables([input_file_1, input_file_2])
+    )
+
+    # assert
+    testing.assert_frame_equal(measure_table_out, measure_table_in)
+    assert measure_table_out.attrs["id"] == "sbp_by_practice"
+    assert measure_table_out.attrs["denominator"] == "population"
+    assert measure_table_out.attrs["group_by"] == ["practice"]
 
 
 def test_drop_zero_denominator_rows():

--- a/tests/test_deciles_charts.py
+++ b/tests/test_deciles_charts.py
@@ -32,11 +32,13 @@ def test_get_measure_tables(tmp_path):
     measure_table_in.to_csv(input_file_2, index=False)
 
     # act
-    measure_table_out = next(
+    measure_tables_out = list(
         deciles_charts.get_measure_tables([input_file_1, input_file_2])
     )
 
     # assert
+    assert len(measure_tables_out) == 1
+    measure_table_out = measure_tables_out[0]
     testing.assert_frame_equal(measure_table_out, measure_table_in)
     assert measure_table_out.attrs["id"] == "sbp_by_practice"
     assert measure_table_out.attrs["denominator"] == "population"

--- a/tests/test_deciles_charts.py
+++ b/tests/test_deciles_charts.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pandas
 import pytest
 from pandas import testing
@@ -101,5 +103,5 @@ def test_parse_args(tmp_path, monkeypatch):
     args = deciles_charts.parse_args()
 
     # assert
-    args.input_dir == "input"
-    args.output_dir == "output"
+    assert args.input_dir == pathlib.Path("input")
+    assert args.output_dir == pathlib.Path("output")

--- a/tests/test_deciles_charts.py
+++ b/tests/test_deciles_charts.py
@@ -1,5 +1,3 @@
-import pathlib
-
 import pandas
 import pytest
 from pandas import testing
@@ -103,11 +101,12 @@ def test_parse_args(tmp_path, monkeypatch):
         input_file.touch()
         input_files.append(input_file)
 
-    (tmp_path / "output").mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
 
     # act
     args = deciles_charts.parse_args()
 
     # assert
     assert sorted(args.input_files) == sorted(input_files)
-    assert args.output_dir == pathlib.Path("output")
+    assert args.output_dir == output_dir


### PR DESCRIPTION
This PR allows us to specify an input glob pattern, rather than an input path, allowing deciles-charts to read a subset of the measure tables.

94e233ee26fdc0200de8f518fdfb39c06e83eba2 addresses the substantive issue; the other commits either fix a broken test 😳 or tidy up.