### PR TITLE
Drop zero-denominator rows correctly

### DIFF
--- a/analysis/deciles_charts.py
+++ b/analysis/deciles_charts.py
@@ -14,10 +14,6 @@ def _get_denominator(measure_table):
     return measure_table.columns[-3]
 
 
-def _get_group_by(measure_table):
-    return list(measure_table.columns[:-4])
-
-
 def get_measure_tables(input_files):
     for input_file in input_files:
         measure_fname_match = re.match(MEASURE_FNAME_REGEX, input_file.name)
@@ -29,7 +25,6 @@ def get_measure_tables(input_files):
             # the study definition.
             measure_table.attrs["id"] = measure_fname_match.group("id")
             measure_table.attrs["denominator"] = _get_denominator(measure_table)
-            measure_table.attrs["group_by"] = _get_group_by(measure_table)
 
             yield measure_table
 

--- a/tests/test_deciles_charts.py
+++ b/tests/test_deciles_charts.py
@@ -42,7 +42,6 @@ def test_get_measure_tables(tmp_path):
     testing.assert_frame_equal(measure_table_out, measure_table_in)
     assert measure_table_out.attrs["id"] == "sbp_by_practice"
     assert measure_table_out.attrs["denominator"] == "population"
-    assert measure_table_out.attrs["group_by"] == ["practice"]
 
 
 def test_drop_zero_denominator_rows():

--- a/tests/test_deciles_charts.py
+++ b/tests/test_deciles_charts.py
@@ -1,3 +1,4 @@
+import numpy
 import pandas
 from pandas import testing
 
@@ -41,7 +42,6 @@ def test_get_measure_tables(tmp_path):
     measure_table_out = measure_tables_out[0]
     testing.assert_frame_equal(measure_table_out, measure_table_in)
     assert measure_table_out.attrs["id"] == "sbp_by_practice"
-    assert measure_table_out.attrs["denominator"] == "population"
 
 
 def test_drop_zero_denominator_rows():
@@ -51,21 +51,19 @@ def test_drop_zero_denominator_rows():
             "practice": [1, 2],
             "has_sbp_event": [0, 1],
             "population": [0, 1],
-            "value": [0, 1],
+            "value": [numpy.inf, 1.0],
             "date": ["2021-01-01", "2021-01-01"],
         }
     )
-    measure_table.attrs["denominator"] = "population"
     exp_measure_table = pandas.DataFrame(
         {
             "practice": [2],
             "has_sbp_event": [1],
             "population": [1],
-            "value": [1],
+            "value": [1.0],
             "date": ["2021-01-01"],
         }
     )
-    exp_measure_table.attrs["denominator"] = "population"
 
     # act
     obs_measure_table = deciles_charts.drop_zero_denominator_rows(measure_table)


### PR DESCRIPTION
Essentially, the code for sniffing a measure table's metadata doesn't work for all measure tables. However, we don't need to sniff: instead, we can test the value column for `inf`. Thank you, as ever, for your help @ccunningham101 🙂.

Fixes #17