### PR TITLE
Show outer percentiles

### DIFF
--- a/analysis/deciles_charts.py
+++ b/analysis/deciles_charts.py
@@ -51,8 +51,8 @@ def drop_zero_denominator_rows(measure_table):
     return measure_table[is_not_inf].reset_index(drop=True)
 
 
-def get_deciles_chart(measure_table):
-    return charts.deciles_chart(measure_table, period_column="date", column="value")
+def get_deciles_chart(measure_table, show_outer_percentiles):
+    return charts.deciles_chart(measure_table, period_column="date", column="value", show_outer_percentiles=show_outer_percentiles)
 
 
 def write_deciles_chart(deciles_chart, path):
@@ -99,7 +99,7 @@ def main():
 
     for measure_table in get_measure_tables(input_files):
         measure_table = drop_zero_denominator_rows(measure_table)
-        chart = get_deciles_chart(measure_table)
+        chart = get_deciles_chart(measure_table, show_outer_percentiles=show_outer_percentiles)
         id_ = measure_table.attrs["id"]
         fname = f"deciles_chart_{id_}.png"
         write_deciles_chart(chart, output_dir / fname)

--- a/analysis/deciles_charts.py
+++ b/analysis/deciles_charts.py
@@ -81,6 +81,13 @@ def parse_args():
         type=get_path,
         help="Path to the output directory",
     )
+    parser.add_argument(
+        "--show-outer-percentiles",
+        required=False,
+        default=False,
+        actions="store_true",
+        help="Show the outer percentiles (1-9 & 91-99)"
+    )
     return parser.parse_args()
 
 
@@ -88,6 +95,7 @@ def main():
     args = parse_args()
     input_files = args.input_files
     output_dir = args.output_dir
+    show_outer_percentiles=args.show_outer_percentiles
 
     for measure_table in get_measure_tables(input_files):
         measure_table = drop_zero_denominator_rows(measure_table)

--- a/analysis/deciles_charts.py
+++ b/analysis/deciles_charts.py
@@ -85,7 +85,7 @@ def parse_args():
         "--show-outer-percentiles",
         required=False,
         default=False,
-        actions="store_true",
+        action="store_true",
         help="Show the outer percentiles (1-9 & 91-99)"
     )
     return parser.parse_args()

--- a/project.yaml
+++ b/project.yaml
@@ -29,6 +29,7 @@ actions:
       python:latest analysis/deciles_charts.py
         --input-files output/measure_*.csv
         --output-dir output
+        --show-outer-percentiles
     needs: [generate_measures]
     outputs:
       moderately_sensitive:


### PR DESCRIPTION
This exposes the the `show_outer_percentiles` argument to address #21.

It assumes the default behaviour should be to exclude the outer percentiles, which I think is the most common use case, but happy to switch around.

I can update readme etc if the changes look good