### PR TITLE
Optionally output deciles charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,19 @@ generate_deciles_charts:
       --input-files output/measure_*.csv
       --output-dir output
   config:
-    show_outer_percentiles: true
+    show_outer_percentiles: false
+    charts:
+      output: true
   needs: [generate_measures]
   outputs:
     moderately_sensitive:
       deciles_charts: output/deciles_chart_*.png
 ```
 
-| Configuration            | Default | Description                                                 |
-| ------------------------ | ------- | ----------------------------------------------------------- |
-| `show_outer_percentiles` | `false` | Show the top and bottom percentiles, as well as the deciles |
+| Configuration            | Description                                                                                         |
+| ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `show_outer_percentiles` | Show the top and bottom percentiles, as well as the deciles                                         |
+| `charts.output`          | Generate a deciles chart for each measure table that is matched by the `--input-files` glob pattern |
 
 ## Notes for developers
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ generate_deciles_charts:
   run: >
     deciles-charts:[version]
       --input-files output/measure_*.csv
-      --output_dir output
+      --output-dir output
   needs: [generate_measures]
   outputs:
     moderately_sensitive:
@@ -77,7 +77,7 @@ generate_deciles_charts:
   run: >
     deciles-charts:[version]
       --input-files output/measure_*.csv
-      --output_dir output
+      --output-dir output
   config:
     show_outer_percentiles: true
   needs: [generate_measures]

--- a/analysis/deciles_charts.py
+++ b/analysis/deciles_charts.py
@@ -26,6 +26,9 @@ logger.addHandler(handler)
 
 DEFAULT_CONFIG = {
     "show_outer_percentiles": False,
+    "charts": {
+        "output": True,
+    },
 }
 
 CONFIG_SCHEMA = {
@@ -33,6 +36,13 @@ CONFIG_SCHEMA = {
     "additionalProperties": False,
     "properties": {
         "show_outer_percentiles": {"type": "boolean"},
+        "charts": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "output": {"type": "boolean"},
+            },
+        },
     },
 }
 
@@ -129,10 +139,11 @@ def main():
 
     for measure_table in get_measure_tables(input_files):
         measure_table = drop_zero_denominator_rows(measure_table)
-        chart = get_deciles_chart(measure_table, config)
-        id_ = measure_table.attrs["id"]
-        fname = f"deciles_chart_{id_}.png"
-        write_deciles_chart(chart, output_dir / fname)
+        if config["charts"]["output"]:
+            chart = get_deciles_chart(measure_table, config)
+            id_ = measure_table.attrs["id"]
+            fname = f"deciles_chart_{id_}.png"
+            write_deciles_chart(chart, output_dir / fname)
 
 
 if __name__ == "__main__":

--- a/project.yaml
+++ b/project.yaml
@@ -29,6 +29,10 @@ actions:
       python:latest analysis/deciles_charts.py
         --input-files output/measure_*.csv
         --output-dir output
+    config:
+      show_outer_percentiles: false
+      charts:
+        output: true
     needs: [generate_measures]
     outputs:
       moderately_sensitive:

--- a/tests/test_deciles_charts.py
+++ b/tests/test_deciles_charts.py
@@ -125,6 +125,7 @@ class TestParseArgs:
         assert sorted(args.input_files) == sorted(input_files)
         assert args.output_dir == output_dir
         assert args.config == deciles_charts.DEFAULT_CONFIG
+        assert args.config is not deciles_charts.DEFAULT_CONFIG  # it is a copy
 
     def test_optional_config_arg(self, monkeypatch):
         # arrange

--- a/tests/test_deciles_charts.py
+++ b/tests/test_deciles_charts.py
@@ -83,20 +83,7 @@ def test_parse_config():
         deciles_charts.parse_config('{"bad_key": "", "worse_key": ""}')
 
 
-@pytest.mark.parametrize(
-    "optional_arg,parsed_optional_arg",
-    [
-        (
-            (),
-            ("config", {"show_outer_percentiles": False}),  # default
-        ),
-        (
-            ("--config", '{"show_outer_percentiles": true}'),
-            ("config", {"show_outer_percentiles": True}),
-        ),
-    ],
-)
-def test_parse_args(tmp_path, monkeypatch, optional_arg, parsed_optional_arg):
+def test_parse_args(tmp_path, monkeypatch):
     # arrange
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
@@ -107,8 +94,7 @@ def test_parse_args(tmp_path, monkeypatch, optional_arg, parsed_optional_arg):
             "input/measure_*.csv",
             "--output-dir",
             "output",
-        ]
-        + list(optional_arg),
+        ],
     )
 
     input_dir = tmp_path / "input"
@@ -137,4 +123,26 @@ def test_parse_args(tmp_path, monkeypatch, optional_arg, parsed_optional_arg):
     # assert
     assert sorted(args.input_files) == sorted(input_files)
     assert args.output_dir == output_dir
-    assert getattr(args, parsed_optional_arg[0]) == parsed_optional_arg[1]
+    assert args.config == deciles_charts.DEFAULT_CONFIG
+
+
+def test_parse_args_config_arg(monkeypatch):
+    # arrange
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "deciles_charts.py",
+            "--input-files",
+            "input/measure_*.csv",
+            "--output-dir",
+            "output",
+            "--config",
+            '{"show_outer_percentiles": true}',
+        ],
+    )
+
+    # act
+    args = deciles_charts.parse_args()
+
+    # assert
+    assert args.config["show_outer_percentiles"]

--- a/tests/test_deciles_charts.py
+++ b/tests/test_deciles_charts.py
@@ -83,66 +83,66 @@ def test_parse_config():
         deciles_charts.parse_config('{"bad_key": "", "worse_key": ""}')
 
 
-def test_parse_args(tmp_path, monkeypatch):
-    # arrange
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(
-        "sys.argv",
-        [
-            "deciles_charts.py",
-            "--input-files",
-            "input/measure_*.csv",
-            "--output-dir",
-            "output",
-        ],
-    )
+class TestParseArgs:
+    def test_positional_args_and_default_optional_args(self, tmp_path, monkeypatch):
+        # arrange
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "deciles_charts.py",
+                "--input-files",
+                "input/measure_*.csv",
+                "--output-dir",
+                "output",
+            ],
+        )
 
-    input_dir = tmp_path / "input"
-    input_dir.mkdir()
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
 
-    input_files = []
-    for input_file_name in [
-        "measure_has_sbp_event_by_stp_code.csv",
-        "measure_has_sbp_event_by_stp_code_2021-01-01.csv",
-        "measure_has_sbp_event_by_stp_code_2021-02-01.csv",
-        "measure_has_sbp_event_by_stp_code_2021-03-01.csv",
-        "measure_has_sbp_event_by_stp_code_2021-04-01.csv",
-        "measure_has_sbp_event_by_stp_code_2021-05-01.csv",
-        "measure_has_sbp_event_by_stp_code_2021-06-01.csv",
-    ]:
-        input_file = input_dir / input_file_name
-        input_file.touch()
-        input_files.append(input_file)
+        input_files = []
+        for input_file_name in [
+            "measure_has_sbp_event_by_stp_code.csv",
+            "measure_has_sbp_event_by_stp_code_2021-01-01.csv",
+            "measure_has_sbp_event_by_stp_code_2021-02-01.csv",
+            "measure_has_sbp_event_by_stp_code_2021-03-01.csv",
+            "measure_has_sbp_event_by_stp_code_2021-04-01.csv",
+            "measure_has_sbp_event_by_stp_code_2021-05-01.csv",
+            "measure_has_sbp_event_by_stp_code_2021-06-01.csv",
+        ]:
+            input_file = input_dir / input_file_name
+            input_file.touch()
+            input_files.append(input_file)
 
-    output_dir = tmp_path / "output"
-    output_dir.mkdir()
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
 
-    # act
-    args = deciles_charts.parse_args()
+        # act
+        args = deciles_charts.parse_args()
 
-    # assert
-    assert sorted(args.input_files) == sorted(input_files)
-    assert args.output_dir == output_dir
-    assert args.config == deciles_charts.DEFAULT_CONFIG
+        # assert
+        assert sorted(args.input_files) == sorted(input_files)
+        assert args.output_dir == output_dir
+        assert args.config == deciles_charts.DEFAULT_CONFIG
 
+    def test_optional_config_arg(self, monkeypatch):
+        # arrange
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "deciles_charts.py",
+                "--input-files",
+                "input/measure_*.csv",
+                "--output-dir",
+                "output",
+                "--config",
+                '{"show_outer_percentiles": true}',
+            ],
+        )
 
-def test_parse_args_config_arg(monkeypatch):
-    # arrange
-    monkeypatch.setattr(
-        "sys.argv",
-        [
-            "deciles_charts.py",
-            "--input-files",
-            "input/measure_*.csv",
-            "--output-dir",
-            "output",
-            "--config",
-            '{"show_outer_percentiles": true}',
-        ],
-    )
+        # act
+        args = deciles_charts.parse_args()
 
-    # act
-    args = deciles_charts.parse_args()
-
-    # assert
-    assert args.config["show_outer_percentiles"]
+        # assert
+        assert args.config["show_outer_percentiles"]


### PR DESCRIPTION
This PR follows #26. It involves refactoring several tests, and is opportunistic a couple of times (784307f8a2374c45ca20b59fff35b2bb45cab8a3, 1af03fd37bd4c5df8e49bcc320f35c3e242c93f0), so I'd suggest stepping through commit-by-commit.

The substantive commit is e8671ebe49f6ec5037f8382dc49c11f47631784c. Here, we add some extra configuration, which is discussed briefly in #4 and #18. This configuration allows us to optionally output deciles charts; it isn't especially useful now, but it will be with #18.

Keeping _README.md_ up-to-date is challenging with all reusable actions. However, to minimize the amount we have to remember to copy-and-paste from _project.yaml_, I've decided to invoke deciles-charts with default values for all configuration.