### PR TITLE
Ensure justfile supports Windows

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,16 +2,17 @@
 # so we shell out, as we need VIRTUAL_ENV in the justfile environment
 export VIRTUAL_ENV  := `echo ${VIRTUAL_ENV:-.venv}`
 
-# TODO: make it /scripts on windows?
-export BIN := VIRTUAL_ENV + "/bin"
-export PIP := BIN + "/python -m pip"
+export BIN := VIRTUAL_ENV + if os_family() == "unix" { "/bin" } else { "/Scripts" }
+export PIP := BIN + if os_family() == "unix" { "/python -m pip" } else { "/python.exe -m pip" }
 # enforce our chosen pip compile flags
 export COMPILE := BIN + "/pip-compile --allow-unsafe --generate-hashes"
+
+export DEFAULT_PYTHON := if os_family() == "unix" { "python3.8" } else { "python" }
 
 
 # list available commands
 default:
-    @{{ just_executable() }} --list
+    @"{{ just_executable() }}" --list
 
 
 # clean up temporary files
@@ -23,7 +24,7 @@ clean:
 virtualenv:
     #!/usr/bin/env bash
     # allow users to specify python version in .env
-    PYTHON_VERSION=${PYTHON_VERSION:-python3.8}
+    PYTHON_VERSION=${PYTHON_VERSION:-$DEFAULT_PYTHON}
 
     # create venv and upgrade pip
     test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install --upgrade pip; }
@@ -32,20 +33,21 @@ virtualenv:
     test -e $BIN/pip-compile || $PIP install pip-tools
 
 
-# update requirements.prod.txt if requirement.prod.in has changed
-requirements-prod: virtualenv
+_compile src dst *args: virtualenv
     #!/usr/bin/env bash
-    # exit if .in file is older than .txt file (-nt = 'newer than', but we negate with || to avoid error exit code)
-    test requirements.prod.in -nt requirements.prod.txt || exit 0
-    $COMPILE --output-file=requirements.prod.txt requirements.prod.in
+    # exit if src file is older than dst file (-nt = 'newer than', but we negate with || to avoid error exit code)
+    test "${FORCE:-}" = "true" -o {{ src }} -nt {{ dst }} || exit 0
+    $BIN/pip-compile --allow-unsafe --generate-hashes --output-file={{ dst }} {{ src }} {{ args }}
+
+
+# update requirements.prod.txt if requirements.prod.in has changed
+requirements-prod *args:
+    "{{ just_executable() }}" _compile requirements.prod.in requirements.prod.txt {{ args }}
 
 
 # update requirements.dev.txt if requirements.dev.in has changed
-requirements-dev: requirements-prod
-    #!/usr/bin/env bash
-    # exit if .in file is older than .txt file (-nt = 'newer than', but we negate with || to avoid error exit code)
-    test requirements.dev.in -nt requirements.dev.txt || exit 0
-    $COMPILE --output-file=requirements.dev.txt requirements.dev.in
+requirements-dev *args: requirements-prod
+    "{{ just_executable() }}" _compile requirements.dev.in requirements.dev.txt {{ args }}
 
 
 # ensure prod requirements installed and up to date
@@ -78,12 +80,12 @@ install-precommit:
     test -f $BASE_DIR/.git/hooks/pre-commit || $BIN/pre-commit install
 
 
-# upgrade dev or prod dependencies (all by default, specify package to upgrade single package)
+# upgrade dev or prod dependencies (specify package to upgrade single package, all by default)
 upgrade env package="": virtualenv
     #!/usr/bin/env bash
     opts="--upgrade"
     test -z "{{ package }}" || opts="--upgrade-package {{ package }}"
-    $COMPILE $opts --output-file=requirements.{{ env }}.txt requirements.{{ env }}.in
+    FORCE=true "{{ just_executable() }}" requirements-{{ env }} $opts
 
 
 # *ARGS is variadic, 0 or more. This allows us to do `just test -k match`, for example.

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -7,7 +7,9 @@
 appnope==0.1.3 \
     --hash=sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24 \
     --hash=sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e
-    # via -r requirements.dev.in
+    # via
+    #   -r requirements.dev.in
+    #   ipython
 asttokens==2.0.5 \
     --hash=sha256:0844691e88552595a6f4a4281a9f7f79b8dd45ca4ccea82e5e05b4bbdb76705c \
     --hash=sha256:9a54c114f02c7a9480d56550932546a3f1fe71d8a02f1bc7ccd0ee3ee35cf4d5


### PR DESCRIPTION
This copies justfile from opensafely-core/repo-template, remembering to
downgrade Python from 3.10 to 3.8, because opensafely-core/python-docker
supports 3.8.