### PR TITLE
Tag new versions sequentially

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,10 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
+  merge_group:
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   check:
@@ -43,15 +44,3 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: opensafely-core/research-action@v2
-
-  tag-new-version:
-    needs: [test-integration]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Tag new version
-        uses: mathieudutour/github-tag-action@d745f2e74aaf1ee82e747b181f7a0967978abee0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          create_annotated_tag: true

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,27 @@
+---
+name: Tag new version
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: tag-new-version
+
+jobs:
+  ci:
+    uses: ./.github/workflows/main.yml
+
+  tag-new-version:
+    needs: [ci]
+    runs-on: ubuntu-latest
+
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Tag new version
+        uses: mathieudutour/github-tag-action@d745f2e74aaf1ee82e747b181f7a0967978abee0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          create_annotated_tag: true

--- a/project.yaml
+++ b/project.yaml
@@ -38,4 +38,4 @@ actions:
     needs: [generate_measures]
     outputs:
       moderately_sensitive:
-        deciles_charts: output/deciles_*_*.*
+        deciles_charts: output/deciles_*_*.png


### PR DESCRIPTION
By moving the tag-new-version job into a new workflow, and making this workflow dependant on the CI workflow, we ensure that new versions are tagged sequentially. Doing so removes the risk of a race condition tagging new versions in an incorrect order.

As a bonus, we also run the CI workflow more frequently: not only on push to the main branch, but also following several other events. Doing so ensures that new versions are correct, insofar as the check, test, and test-integration jobs are concerned.

And as another bonus, we fix a ProjectValidationError.

Of course, in a more important repository (and to help future archaeologists understand what we changed and why we changed it), we'd split the fix and the two bonuses into three separate PRs. However, this isn't an important repository!

Fixes #113